### PR TITLE
Added ids to messages that are required by advise

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.networking.data/.classpath
+++ b/org.palladiosimulator.analyzer.slingshot.networking.data/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/org.palladiosimulator.analyzer.slingshot.networking.data/.project
+++ b/org.palladiosimulator.analyzer.slingshot.networking.data/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1725291776825</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/org.palladiosimulator.analyzer.slingshot.networking.data/src/org/palladiosimulator/analyzer/slingshot/networking/data/EventMessage.java
+++ b/org.palladiosimulator.analyzer.slingshot.networking.data/src/org/palladiosimulator/analyzer/slingshot/networking/data/EventMessage.java
@@ -11,14 +11,24 @@ import org.palladiosimulator.analyzer.slingshot.common.events.SystemEvent;
  * @param <T> Payload type
  */
 public abstract class EventMessage<T> extends Message<T> implements SystemEvent {
+	private static final UUID CLIENT_ID = UUID.randomUUID();
+	public static UUID EXPLORATION_ID;
 	private final UUID id = UUID.randomUUID();
+	// Copy as non static to allow serialization
+	private final UUID clientId;
+	private final UUID explorationId;
+	
 
 	public EventMessage(final String event, final T payload) {
 		super(event, payload, "Explorer");
+		this.clientId = CLIENT_ID;
+		this.explorationId = EXPLORATION_ID;
 	}
 
 	public EventMessage(final String event, final T payload, final String creator) {
 		super(event, payload, creator);
+		this.clientId = CLIENT_ID;
+		this.explorationId = EXPLORATION_ID;
 	}
 
 	@Override

--- a/org.palladiosimulator.analyzer.slingshot.networking/src/org/palladiosimulator/analyzer/slingshot/networking/NetworkingModule.java
+++ b/org.palladiosimulator.analyzer.slingshot.networking/src/org/palladiosimulator/analyzer/slingshot/networking/NetworkingModule.java
@@ -25,7 +25,7 @@ public class NetworkingModule extends AbstractSlingshotExtension {
 
 		bind(GsonProvider.class);
 		try {
-			final var client = new SlingshotWebsocketClient(new URI("ws://localhost:9006"));
+			final var client = new SlingshotWebsocketClient(new URI("ws://localhost:8080/ws"));
 			bind(SlingshotWebsocketClient.class).toInstance(client);
 			this.requestInjection(client);
 		} catch (final URISyntaxException e) {


### PR DESCRIPTION
Advise requires the message to have a clientId and an explorationId.

In the future we should change the way the explorationId is set (see https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-StateExploration/pull/32)